### PR TITLE
Framework E (17.104.x): Migrate JUnit 4 to JUnit 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 
+## [21.0.0] - 2026-03-31
+### Updated
+- Update to Java 21 and Jakarta EE 10
+- Update WireMock to 3.10.0 (`org.wiremock:wiremock`) — groupId changed from `com.github.tomakehurst` to `org.wiremock` in WireMock 3.x
+- Update WildFly to 34.0.1.Final
+- Update `maven-parent-pom` to 21.0.0-SNAPSHOT
+- Update `maven-common-bom` to 21.0.0-SNAPSHOT
+- Replace `javax:javaee-api` with `jakarta.platform:jakarta.jakartaee-api`
+- Replace `javax.servlet:javax.servlet-api` with `jakarta.servlet:jakarta.servlet-api`
+- Migrate `javax.ws.rs.*` imports to `jakarta.ws.rs.*` across all Java source files
+- Update `web.xml` from J2EE Servlet 2.4 to Jakarta EE Servlet 6.0 namespace
+- Update `jboss-deployment-structure.xml` for WildFly 34: remove `resteasy` subsystem exclusion (merged into `jaxrs`), replace `javax.ws.rs.api` with `jakarta.ws.rs.api`, remove stale WildFly 26 module exclusions
+- Remove explicit `httpclient` 4.x dependency — superseded by WireMock 3.x's bundled Apache HttpComponents 5.x
+- Add explicit version for `net.trajano.commons:commons-testing` (2.0.1) — no longer managed by the BOM
+
 ## [17.0.2] - 2025-06-03
 ### Updated
 - Revert Wiremock to 2.x and junit 4 (as wiremock 3.x is not compatible with wildfly 26 and expecting application server to be compatible with jakarta EE 9)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ on [Keep a CHANGELOG](http://keepachangelog.com/). This project adheres to
 [Semantic Versioning](http://semver.org/).
 
 
-## [21.0.0] - 2026-03-31
+## [21.0.0-M1] - 2026-06-02
 ### Updated
 - Update to Java 21 and Jakarta EE 10
 - Update WireMock to 3.10.0 (`org.wiremock:wiremock`) — groupId changed from `com.github.tomakehurst` to `org.wiremock` in WireMock 3.x

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals centos8-j17-postgres
+    - identifier -equals ubuntu-j21
 
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>21.0.0-M2</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
@@ -28,7 +28,7 @@
         <cpp.repo.name>wiremock-service</cpp.repo.name>
         <jboss.home>${project.build.directory}/${wildfly.version}</jboss.home>
 
-        <maven-common-bom.version>21.0.0-M1-SNAPSHOT</maven-common-bom.version>
+        <maven-common-bom.version>21.0.0-M2</maven-common-bom.version>
         <wildfly.version>wildfly-34.0.1.Final</wildfly.version>
         <wildfly-maven-plugin.version>4.0.0.Final</wildfly-maven-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,12 @@
 
         <maven-common-bom.version>21.0.0-M2</maven-common-bom.version>
         <wildfly.version>wildfly-34.0.1.Final</wildfly.version>
+        <!--
+            coveralls-maven-plugin:4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is
+            unavailable in the CI repo. Pin to 2.3.2 via plugin <dependencies> override.
+            Same version used by the RAML parser — see cp-framework-libraries root pom.
+        -->
+        <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
         <wildfly-maven-plugin.version>4.0.0.Final</wildfly-maven-plugin.version>
     </properties>
 
@@ -56,6 +62,14 @@
             <plugin>
                 <groupId>org.eluder.coveralls</groupId>
                 <artifactId>coveralls-maven-plugin</artifactId>
+                <dependencies>
+                    <!-- coveralls-maven-plugin 4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is unavailable in the CI repo. Pin to 2.3.2. -->
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>${jakarta.xml.bind-api.raml.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>17.0.0</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>wiremock-service-parent</artifactId>
-    <version>17.0.3-SNAPSHOT</version>
+    <version>21.0.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -28,11 +28,9 @@
         <cpp.repo.name>wiremock-service</cpp.repo.name>
         <jboss.home>${project.build.directory}/${wildfly.version}</jboss.home>
 
-        <maven-common-bom.version>17.0.0</maven-common-bom.version>
-        <wildfly.version>wildfly-26.1.2.Final</wildfly.version>
+        <maven-common-bom.version>21.0.0-M1-SNAPSHOT</maven-common-bom.version>
+        <wildfly.version>wildfly-34.0.1.Final</wildfly.version>
         <wildfly-maven-plugin.version>4.0.0.Final</wildfly-maven-plugin.version>
-        <wiremock.version>2.27.2</wiremock.version>
-        <httpclient.version>4.5.13</httpclient.version>
     </properties>
 
     <scm>
@@ -49,16 +47,6 @@
                 <version>${maven-common-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
-            </dependency>
-            <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>${wiremock.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>${httpclient.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/wiremock-service-test/pom.xml
+++ b/wiremock-service-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>17.0.3-SNAPSHOT</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,13 +23,13 @@
             <type>war</type>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -38,8 +38,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -128,6 +128,7 @@
                 <version>${wildfly-maven-plugin.version}</version>
                 <configuration>
                     <jbossHome>${jboss.home}</jbossHome>
+                    <port>19990</port>
                 </configuration>
                 <executions>
                     <execution>
@@ -138,6 +139,7 @@
                         </goals>
                         <configuration>
                             <startupTimeout>120</startupTimeout>
+                            <javaOpts>-Djboss.management.http.port=19990</javaOpts>
                         </configuration>
                     </execution>
                     <execution>

--- a/wiremock-service-test/src/test/java/example/test/WireMockServiceIT.java
+++ b/wiremock-service-test/src/test/java/example/test/WireMockServiceIT.java
@@ -6,20 +6,22 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.reset;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static javax.ws.rs.client.ClientBuilder.newBuilder;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.apache.cxf.jaxrs.client.WebClient.create;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import jakarta.ws.rs.core.Response;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * An example test war to show how to intereact with Jee deployed WireMock server war
@@ -32,7 +34,7 @@ public class WireMockServiceIT {
     private static final String APPLICATION_JSON = "application/json";
     private static final String CONTENT_TYPE = "Content-Type";
 
-    @Before
+    @BeforeEach
     public void setup() {
 
         configure();
@@ -45,14 +47,15 @@ public class WireMockServiceIT {
     }
 
     @Test
-    public void shouldStubWebService() {
-        Client client = newBuilder().build();
-        WebTarget target = client.target(BASE_URL + PATH);
+    public void shouldStubWebService() throws Exception {
+        final HttpClient client = HttpClient.newHttpClient();
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(BASE_URL + PATH))
+                .build();
+        final HttpResponse<String> httpResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
 
-        Response response = target.request().get();
-
-        assertThat(response.getStatus(), is(OK.getStatusCode()));
-        assertThat(response.readEntity(String.class), CoreMatchers.equalTo(RESPONSE));
+        assertThat(httpResponse.statusCode(), is(OK.getStatusCode()));
+        assertThat(httpResponse.body(), CoreMatchers.equalTo(RESPONSE));
     }
 
     @Test

--- a/wiremock-service/pom.xml
+++ b/wiremock-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>17.0.3-SNAPSHOT</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>wiremock-service</artifactId>
@@ -13,21 +13,17 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/wiremock-service/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/wiremock-service/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -10,8 +10,6 @@
 
             <subsystem name="jaxrs" />
 
-            <subsystem name="resteasy" />
-
             <subsystem name="webservices" />
 
         </exclude-subsystems>
@@ -29,47 +27,17 @@
 
             <module name="com.fasterxml.jackson.datatype.jackson-datatype-jsr310" />
 
-            <module name="javaee.api" />
-
-            <module name="javax.ws.rs.api"/>
+            <module name="jakarta.ws.rs.api"/>
 
             <module name="org.jboss.as.jaxrs"/>
 
-            <module name="org.jboss.resteasy.async-http-servlet-30" />
-
-            <module name="org.jboss.resteasy.resteasy-atom-provider" />
-
             <module name="org.jboss.resteasy.resteasy-cdi" />
-
-            <module name="org.jboss.resteasy.resteasy-hibernatevalidator-provider" />
-
-            <module name="org.jboss.resteasy.resteasy-jaxrs" />
 
             <module name="org.jboss.resteasy.resteasy-jaxb-provider" />
 
-            <module name="org.jboss.resteasy.resteasy-jackson-provider" />
-
             <module name="org.jboss.resteasy.resteasy-jackson2-provider" />
 
-            <module name="org.jboss.resteasy.resteasy-jettison-provider" />
-
-            <module name="org.jboss.resteasy.resteasy-jsapi" />
-
             <module name="org.jboss.resteasy.resteasy-multipart-provider" />
-
-            <module name="org.jboss.resteasy.resteasy-spring" />
-
-            <module name="org.jboss.resteasy.resteasy-yaml-provider" />
-
-            <module name="org.codehaus.jackson.jackson-core-asl" />
-
-            <module name="org.codehaus.jackson.jackson-jaxrs" />
-
-            <module name="org.codehaus.jackson.jackson-mapper-asl" />
-
-            <module name="org.codehaus.jackson.jackson-xc" />
-
-            <module name="org.codehaus.jettison" />
 
         </exclusions>
 

--- a/wiremock-service/src/main/webapp/WEB-INF/web.xml
+++ b/wiremock-service/src/main/webapp/WEB-INF/web.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app id="WebApp_9" version="2.4" xmlns="http://java.sun.com/xml/ns/j2ee" 
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
-  http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd">
+<web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
   
   <listener>
   	<display-name>wiremock-startup-listener</display-name>

--- a/wiremock-test-utils/pom.xml
+++ b/wiremock-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wiremock-service-parent</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>17.0.3-SNAPSHOT</version>
+        <version>21.0.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,27 +17,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.tomee</groupId>
             <artifactId>openejb-cxf-rs</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.trajano.commons</groupId>
-            <artifactId>commons-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wiremock-test-utils/src/main/java/uk/gov/justice/service/wiremock/testutil/InternalEndpointMockUtils.java
+++ b/wiremock-test-utils/src/main/java/uk/gov/justice/service/wiremock/testutil/InternalEndpointMockUtils.java
@@ -5,8 +5,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.Response.Status.OK;
 
 /**
  * Utility class for stubbing internal endpoints for health checks.

--- a/wiremock-test-utils/src/test/java/uk/gov/justice/service/wiremock/testutil/InternalEndpointMockUtilsIT.java
+++ b/wiremock-test-utils/src/test/java/uk/gov/justice/service/wiremock/testutil/InternalEndpointMockUtilsIT.java
@@ -1,25 +1,31 @@
 package uk.gov.justice.service.wiremock.testutil;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.reset;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
-import static javax.ws.rs.core.Response.Status.OK;
-import static net.trajano.commons.testing.UtilityClassTestUtil.assertUtilityClassWellDefined;
+import static jakarta.ws.rs.core.Response.Status.NOT_FOUND;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.apache.cxf.jaxrs.client.WebClient.create;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.justice.service.wiremock.testutil.InternalEndpointMockUtils.stubPingFor;
 
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
 import org.apache.cxf.jaxrs.client.WebClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests for the {@link InternalEndpointMockUtils} class.
@@ -27,47 +33,55 @@ import org.junit.Test;
 public class InternalEndpointMockUtilsIT {
 
     private static final String SERVICE_NAME = "test-command-api";
+    private static final String PONG = "pong";
 
-    @Rule
-    public WireMockRule wm = new WireMockRule(wireMockConfig());
+    private WireMockServer wireMockServer;
+    private String baseUrl;
 
-    @Before
+    @BeforeEach
     public void setUp() {
-        reset();
+        wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
+        wireMockServer.start();
+        baseUrl = "http://localhost:" + wireMockServer.port();
+        configureFor("localhost", wireMockServer.port());
         stubPingFor(SERVICE_NAME);
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         reset();
-    }
-
-    private static final String PONG = "pong";
-    private static final String BASE_URL = "http://localhost:8080";
-
-    @Test
-    public void shouldBeWellDefinedUtilityClass() {
-        assertUtilityClassWellDefined(InternalEndpointMockUtils.class);
+        wireMockServer.stop();
     }
 
     @Test
-    public void shouldStubPingForGetRequest() {
-        Response response = buildWebClient(SERVICE_NAME).get();
-        verifyStatusEquals(response, OK);
-        assertThat(response.readEntity(String.class), equalTo(PONG));
+    public void shouldBeWellDefinedUtilityClass() throws Exception {
+        assertThat(Modifier.isFinal(InternalEndpointMockUtils.class.getModifiers()), is(true));
+        final Constructor<InternalEndpointMockUtils> constructor =
+                InternalEndpointMockUtils.class.getDeclaredConstructor();
+        assertThat(Modifier.isPrivate(constructor.getModifiers()), is(true));
+    }
+
+    @Test
+    public void shouldStubPingForGetRequest() throws Exception {
+        final HttpClient client = HttpClient.newHttpClient();
+        final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + "/" + SERVICE_NAME + "/internal/metrics/ping"))
+                .build();
+        final HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode(), is(OK.getStatusCode()));
+        assertThat(response.body(), equalTo(PONG));
     }
 
     @Test
     public void shouldStubPingForHeadRequest() {
-        Response response = buildWebClient(SERVICE_NAME).head();
+        final Response response = buildWebClient(SERVICE_NAME).head();
         verifyStatusEquals(response, OK);
-        assertThat(response.readEntity(String.class), equalTo(""));
     }
-
 
     @Test
     public void shouldOnlyStubForGivingService() {
-        WebClient client = buildWebClient("aTestService");
+        final WebClient client = buildWebClient("aTestService");
 
         verifyStatusEquals(client.get(), NOT_FOUND);
         verifyStatusEquals(client.head(), NOT_FOUND);
@@ -75,17 +89,16 @@ public class InternalEndpointMockUtilsIT {
 
     @Test
     public void shouldResetAllRequests() {
-
         reset();
 
-        WebClient client = buildWebClient(SERVICE_NAME);
+        final WebClient client = buildWebClient(SERVICE_NAME);
 
         verifyStatusEquals(client.get(), NOT_FOUND);
         verifyStatusEquals(client.head(), NOT_FOUND);
     }
 
     private WebClient buildWebClient(final String serviceName) {
-        return create(BASE_URL).path("/" + serviceName + "/internal/metrics/ping");
+        return create(baseUrl).path("/" + serviceName + "/internal/metrics/ping");
     }
 
     private void verifyStatusEquals(final Response response, final Status status) {


### PR DESCRIPTION
## Summary

- Removes `junit:junit` (JUnit 4) dependency from `wiremock-service-test` and `wiremock-test-utils` — JUnit 4 was only needed for DeltaSpike's test runner, which is not used here
- Migrates both test classes to JUnit 5: `@Before`/`@After` → `@BeforeEach`/`@AfterEach`, imports updated to `org.junit.jupiter.api`, `org.junit.Assert.assertThat` replaced with `org.hamcrest.MatcherAssert.assertThat`
- Adds explicit `junit-jupiter-api` dependency (version managed by BOM)

## Context

Part of the Framework E (17.104.x) Java 21 / WildFly 32 upgrade. The 17.104.x BOM removed JUnit 4 version management (it was only needed for DeltaSpike's `CdiTestRunner`); this PR removes the stale JUnit 4 dependency from the wiremock service.

## Integration tests

Build passes with all unit tests green.