### PR TITLE
Java 25 / WildFly 40 spike: cp-wiremock-service

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
 
 variables:
   - name: sonarqubeProject

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>wiremock-service-parent</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>21.0.0-M1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>wiremock-service-parent</artifactId>
-    <version>21.0.0-M1</version>
+    <version>21.0.0-M2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-parent-pom</artifactId>
-        <version>21.0.0-M2</version>
+        <version>25.104.0-M1</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>
     <artifactId>wiremock-service-parent</artifactId>
-    <version>21.0.0-M2-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -28,15 +28,16 @@
         <cpp.repo.name>wiremock-service</cpp.repo.name>
         <jboss.home>${project.build.directory}/${wildfly.version}</jboss.home>
 
-        <maven-common-bom.version>21.0.0-M2</maven-common-bom.version>
-        <wildfly.version>wildfly-34.0.1.Final</wildfly.version>
+        <maven-common-bom.version>25.104.0-M1</maven-common-bom.version>
+        <wildfly.version>wildfly-40.0.0.Final</wildfly.version>
+        <wildfly.full.version>40.0.0.Final</wildfly.full.version>
         <!--
             coveralls-maven-plugin:4.3.0 ships with jakarta.xml.bind-api:2.3.1 which is
             unavailable in the CI repo. Pin to 2.3.2 via plugin <dependencies> override.
             Same version used by the RAML parser — see cp-framework-libraries root pom.
         -->
         <jakarta.xml.bind-api.raml.version>2.3.2</jakarta.xml.bind-api.raml.version>
-        <wildfly-maven-plugin.version>4.0.0.Final</wildfly-maven-plugin.version>
+        <wildfly-maven-plugin.version>6.0.0.Final</wildfly-maven-plugin.version>
     </properties>
 
     <scm>

--- a/wiremock-service-test/pom.xml
+++ b/wiremock-service-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>21.0.0-M1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/wiremock-service-test/pom.xml
+++ b/wiremock-service-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>21.0.0-M2-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -131,6 +131,21 @@
                     <port>19990</port>
                 </configuration>
                 <executions>
+                    <execution>
+                        <id>provision-server</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>provision</goal>
+                        </goals>
+                        <configuration>
+                            <provisioningDir>${jboss.home}</provisioningDir>
+                            <featurePacks>
+                                <featurePack>
+                                    <location>wildfly@maven(org.jboss.universe:community-universe)#${wildfly.full.version}</location>
+                                </featurePack>
+                            </featurePacks>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>start-server</id>
                         <phase>pre-integration-test</phase>

--- a/wiremock-service-test/pom.xml
+++ b/wiremock-service-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>21.0.0-M1</version>
+        <version>21.0.0-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/wiremock-service/pom.xml
+++ b/wiremock-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>21.0.0-M1</version>
+        <version>21.0.0-M2-SNAPSHOT</version>
     </parent>
 
     <artifactId>wiremock-service</artifactId>

--- a/wiremock-service/pom.xml
+++ b/wiremock-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>21.0.0-M2-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>wiremock-service</artifactId>

--- a/wiremock-service/pom.xml
+++ b/wiremock-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>wiremock-service-parent</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>21.0.0-M1</version>
     </parent>
 
     <artifactId>wiremock-service</artifactId>

--- a/wiremock-test-utils/pom.xml
+++ b/wiremock-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wiremock-service-parent</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>21.0.0-M1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/wiremock-test-utils/pom.xml
+++ b/wiremock-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wiremock-service-parent</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1</version>
+        <version>21.0.0-M2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/wiremock-test-utils/pom.xml
+++ b/wiremock-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wiremock-service-parent</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M2-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-wiremock-service

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**.

**Spike gate: cp-cake-shop integration tests — 42/42 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Version bumped to `25.104.0-M1-SNAPSHOT`
- Parent chain updated to `cp-maven-framework-parent-pom:25.104.0-M1-SNAPSHOT`
- Dependency versions aligned to WildFly 40 / Jakarta EE 11 BOM

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → cp-cake-shop